### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,11 @@
 # Datatypes
 
-OnePush  KEYWORD1
+OnePush	KEYWORD1
 
 # Methods and Functions
 
-status   KEYWORD2
-state    KEYWORD2
-level    KEYWORD2
-set      KEYWORD2
-next     KEYWORD2
+status	KEYWORD2
+state	KEYWORD2
+level	KEYWORD2
+set	KEYWORD2
+next	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords